### PR TITLE
Update background color when switching between light and dark mode.

### DIFF
--- a/Sources/Toast/ToastViews/AppleToastView/AppleToastView.swift
+++ b/Sources/Toast/ToastViews/AppleToastView/AppleToastView.swift
@@ -54,6 +54,12 @@ public class AppleToastView : UIView, ToastView {
         style()
     }
     
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        UIView.animate(withDuration: 0.5) {
+            self.style()
+        }
+    }
+    
     private func style() {
         layoutIfNeeded()
         clipsToBounds = true


### PR DESCRIPTION
Before, when switching between light and dark mode, the Toast's background color stayed the same. Now it will switch to the correct background color while it is being shown.

The default title color is UIColor.label which would update during the switch, but the background color wouldn't. This resulted in unreadable text.