### PR TITLE
Add support for iOS 12.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Toast",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v12)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/Toast/Toast.swift
+++ b/Sources/Toast/Toast.swift
@@ -8,6 +8,14 @@
 import UIKit
 
 public class Toast {
+    public static var defaultImageTint: UIColor {
+        if #available(iOS 13.0, *) {
+            return .label
+        } else {
+            return .black
+        }
+    }
+    
     public let view: ToastView
 
     private let config: ToastConfiguration
@@ -41,7 +49,7 @@ public class Toast {
     /// - Returns: A new Toast view with the configured layout
     public static func `default`(
         image: UIImage,
-        imageTint: UIColor? = .label,
+        imageTint: UIColor? = defaultImageTint,
         title: String,
         subtitle: String? = nil,
         config: ToastConfiguration = ToastConfiguration()

--- a/Sources/Toast/ToastViews/AppleToastView/IconAppleToastView.swift
+++ b/Sources/Toast/ToastViews/AppleToastView/IconAppleToastView.swift
@@ -9,7 +9,15 @@ import Foundation
 import UIKit
 
 public class IconAppleToastView : UIStackView {
-    public init(image: UIImage, imageTint: UIColor? = .label, title: String, subtitle: String? = nil) {
+    public static var defaultImageTint: UIColor {
+        if #available(iOS 13.0, *) {
+            return .label
+        } else {
+            return .black
+        }
+    }
+    
+    public init(image: UIImage, imageTint: UIColor? = defaultImageTint, title: String, subtitle: String? = nil) {
         super.init(frame: CGRect.zero)
         axis = .horizontal
         spacing = 15

--- a/ToastViewSwift.podspec
+++ b/ToastViewSwift.podspec
@@ -65,7 +65,7 @@ Pod::Spec.new do |spec|
   #
 
   # spec.platform     = :ios
-  spec.platform     = :ios, "13.0"
+  spec.platform     = :ios, "12.0"
 
   #  When using multiple platforms
   # spec.ios.deployment_target = "5.0"


### PR DESCRIPTION
I want to use this library in an app that still needs to support iOS 12. Apart from the default `imageTint` being `UIColor.label`, it works perfectly fine on iOS 12.