### PR TITLE
Add support for iOS 11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Toast",
     platforms: [
-        .iOS(.v12)
+        .iOS(.v11)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/Toast/ToastViews/AppleToastView/AppleToastView.swift
+++ b/Sources/Toast/ToastViews/AppleToastView/AppleToastView.swift
@@ -64,7 +64,11 @@ public class AppleToastView : UIView, ToastView {
         layoutIfNeeded()
         clipsToBounds = true
         layer.cornerRadius = frame.height / 2
-        backgroundColor = traitCollection.userInterfaceStyle == .light ? lightBackgroundColor : darkBackgroundColor
+        if #available(iOS 12.0, *) {
+            backgroundColor = traitCollection.userInterfaceStyle == .light ? lightBackgroundColor : darkBackgroundColor
+        } else {
+            backgroundColor = lightBackgroundColor
+        }
         
         addShadow()
     }

--- a/ToastViewSwift.podspec
+++ b/ToastViewSwift.podspec
@@ -65,7 +65,7 @@ Pod::Spec.new do |spec|
   #
 
   # spec.platform     = :ios
-  spec.platform     = :ios, "12.0"
+  spec.platform     = :ios, "11.0"
 
   #  When using multiple platforms
   # spec.ios.deployment_target = "5.0"


### PR DESCRIPTION
I had to used this library on an app that still support iOS 11.
To make it works on iOS 11 i had to assign backgroundColor = lightBackgroundColor when userInterfaceStyle is not available.