### PR TITLE
Update AppleToastView.swift

### DIFF
--- a/Sources/Toast/ToastViews/AppleToastView/AppleToastView.swift
+++ b/Sources/Toast/ToastViews/AppleToastView/AppleToastView.swift
@@ -51,7 +51,9 @@ public class AppleToastView : UIView, ToastView {
         ])
         
         addSubviewConstraints()
-        style()
+        DispatchQueue.main.async {
+            self.style()
+        }
     }
     
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {


### PR DESCRIPTION
On iOS 15.4 the toast doesn't show perfect rounded, printing `frame.height` on `style()` seems to be less than 58 that is minHeight.
Calling style async during create toast fixes the problem.

![Simulator Screen Shot - iPhone 13 - 2022-05-06 at 08 37 52](https://user-images.githubusercontent.com/76693958/167073841-b21598a7-4df1-4bdc-8ed8-4e9c9ae2161d.png)

