### PR TITLE
Adding `TapToClose` and `PanToClose` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ let toast = Toast.default(
 toast.show()
 ```
 
+If you want to tap to close the Toast, calling `enableTapToClose()`:
+```swift
+toast.enableTapToClose()
+toast.show()
+```
+
 Want to use a different layout, but still use the Apple style? Create your own view and inject it into the `AppleToastView` class when creating a custom toast:
 ```swift
 let customView: UIView = // Custom view
@@ -63,18 +69,20 @@ toast.show(haptic: .success, after: 1)
 
 ### Configuration options    
 The `text`, `default` and `custom` methods support custom configuration options. The following options are available:
+
 | Name            | Description                                                                                         | Type           | Default |
 |-----------------|-----------------------------------------------------------------------------------------------------|----------------|---------|
 | `autoHide`      | When set to true, the toast will automatically close itself after display time has elapsed.         | `Bool`         | `true`  |
+| `enablePanToClose`      | When set to true, the toast will be able to close by swiping up.         | `Bool`         | `true`  |
 | `displayTime`   | The duration the toast will be displayed before it will close when autoHide set to true in seconds. | `TimeInterval` | `4`     |
 | `animationTime` | Duration of the show and close animation in seconds.                                                | `TimeInterval` | `0.2`   |
 | `attachTo`      | The view which the toast view will be attached to.                                                  | `UIView`       | `nil`   |
 
 
-
 ```swift
 let config = ToastConfiguration(
     autoHide: true,
+    enablePanToClose: true,
     displayTime: 5,
     animationTime: 0.2
 )

--- a/Sources/Toast/ToastConfiguration.swift
+++ b/Sources/Toast/ToastConfiguration.swift
@@ -10,6 +10,7 @@ import UIKit
 
 public struct ToastConfiguration {
     public let autoHide: Bool
+    public let enablePanToClose: Bool
     public let displayTime: TimeInterval
     public let animationTime: TimeInterval
     
@@ -19,16 +20,19 @@ public struct ToastConfiguration {
     /// Creates a new Toast configuration object.
     /// - Parameters:
     ///   - autoHide: When set to true, the toast will automatically close itself after display time has elapsed.
+    ///   - enablePanToClose: When set to true, the toast will be able to close by swiping up.
     ///   - displayTime: The duration the toast will be displayed before it will close when autoHide set to true.
     ///   - animationTime:Duration of the animation
     ///   - attachTo: The view on which the toast view will be attached.
     public init(
         autoHide: Bool = true,
+        enablePanToClose: Bool = true,
         displayTime: TimeInterval = 4,
         animationTime: TimeInterval = 0.2,
         attachTo view: UIView? = nil
     ) {
         self.autoHide = autoHide
+        self.enablePanToClose = enablePanToClose
         self.displayTime = displayTime
         self.animationTime = animationTime
         self.view = view


### PR DESCRIPTION
Greetings,
I added the feature for #12 and Pan gesture to close Toast.

The main changing is using Timer to handle close(), so when trigger gesture, it won't conflict with UIView.animate()

![CleanShot 2022-07-28 at 16 04 03 3](https://user-images.githubusercontent.com/32888552/181454720-fa237aa7-dbf1-4f11-b294-ee1290e3d357.gif)

Hope it helps ;-)
