### PR TITLE
Add delegate for show and close callbacks.

### DIFF
--- a/Sources/Toast/Toast.swift
+++ b/Sources/Toast/Toast.swift
@@ -23,6 +23,8 @@ public class Toast {
     }
     
     public let view: ToastView
+
+    public weak var delegate: ToastDelegate?
     
     private let config: ToastConfiguration
     
@@ -108,6 +110,8 @@ public class Toast {
         config.view?.addSubview(view) ?? topController()?.view.addSubview(view)
         view.createView(for: self)
         
+        delegate?.didShowToast(self)
+
         UIView.animate(withDuration: config.animationTime, delay: delay, options: [.curveEaseOut, .allowUserInteraction]) {
             self.view.transform = .identity
         } completion: { [self] _ in
@@ -131,6 +135,7 @@ public class Toast {
         }, completion: { _ in
             self.view.removeFromSuperview()
             completion?()
+            self.delegate?.didCloseToast(self)
         })
     }
     

--- a/Sources/Toast/Toast.swift
+++ b/Sources/Toast/Toast.swift
@@ -110,11 +110,12 @@ public class Toast {
         config.view?.addSubview(view) ?? topController()?.view.addSubview(view)
         view.createView(for: self)
         
-        delegate?.didShowToast(self)
+        delegate?.willShowToast(self)
 
         UIView.animate(withDuration: config.animationTime, delay: delay, options: [.curveEaseOut, .allowUserInteraction]) {
             self.view.transform = .identity
         } completion: { [self] _ in
+            delegate?.didShowToast(self)
             closeTimer = Timer.scheduledTimer(withTimeInterval: .init(config.displayTime), repeats: false) { [self] _ in
                 if config.autoHide {
                     close()
@@ -127,6 +128,8 @@ public class Toast {
     /// - Parameters:
     ///   - completion: A completion handler which is invoked after the toast is hidden
     public func close(completion: (() -> Void)? = nil) {
+        delegate?.willCloseToast(self)
+
         UIView.animate(withDuration: config.animationTime,
                        delay: 0,
                        options: [.curveEaseIn, .allowUserInteraction],

--- a/Sources/Toast/ToastDelegate.swift
+++ b/Sources/Toast/ToastDelegate.swift
@@ -9,10 +9,24 @@ import Foundation
 
 public protocol ToastDelegate: AnyObject {
 
+    /// Delegate function that will be called before the Toast is shown.
+    /// - Parameters:
+    ///   - toast: The toast that will be shown.
     func willShowToast(_ toast: Toast)
+
+    /// Delegate function that will be called after the Toast is shown.
+    /// - Parameters:
+    ///   - toast: The toast that was just shown.
     func didShowToast(_ toast: Toast)
 
+    /// Delegate function that will be called before the Toast is closed.
+    /// - Parameters:
+    ///   - toast: The toast that will be closed.
     func willCloseToast(_ toast: Toast)
+
+    /// Delegate function that will be called after the Toast is closed.
+    /// - Parameters:
+    ///   - toast: The toast that was just closed.
     func didCloseToast(_ toast: Toast)
 
 }
@@ -20,9 +34,11 @@ public protocol ToastDelegate: AnyObject {
 extension ToastDelegate {
 
     func willShowToast(_ toast: Toast) {}
+
     func didShowToast(_ toast: Toast) {}
 
     func willCloseToast(_ toast: Toast) {}
+
     func didCloseToast(_ toast: Toast) {}
 
 }

--- a/Sources/Toast/ToastDelegate.swift
+++ b/Sources/Toast/ToastDelegate.swift
@@ -13,3 +13,10 @@ public protocol ToastDelegate: AnyObject {
     func didCloseToast(_ toast: Toast)
 
 }
+
+extension ToastDelegate {
+
+    func didShowToast(_ toast: Toast) {}
+    func didCloseToast(_ toast: Toast) {}
+
+}

--- a/Sources/Toast/ToastDelegate.swift
+++ b/Sources/Toast/ToastDelegate.swift
@@ -9,14 +9,20 @@ import Foundation
 
 public protocol ToastDelegate: AnyObject {
 
+    func willShowToast(_ toast: Toast)
     func didShowToast(_ toast: Toast)
+
+    func willCloseToast(_ toast: Toast)
     func didCloseToast(_ toast: Toast)
 
 }
 
 extension ToastDelegate {
 
+    func willShowToast(_ toast: Toast) {}
     func didShowToast(_ toast: Toast) {}
+
+    func willCloseToast(_ toast: Toast) {}
     func didCloseToast(_ toast: Toast) {}
 
 }

--- a/Sources/Toast/ToastDelegate.swift
+++ b/Sources/Toast/ToastDelegate.swift
@@ -1,0 +1,15 @@
+//
+//  ToastDelegate.swift
+//  Toast
+//
+//  Created by Zandor Smith on 01/11/2022.
+//
+
+import Foundation
+
+public protocol ToastDelegate: AnyObject {
+
+    func didShowToast(_ toast: Toast)
+    func didCloseToast(_ toast: Toast)
+
+}


### PR DESCRIPTION
Adds a `ToastDelegate` per requested in https://github.com/BastiaanJansen/toast-swift/issues/16

## Usage

```swift
let toast = Toast.text("Safari pasted from Notes", subtitle: "A few seconds ago")
toast.delegate = self
toast.show()
```

Below delegate functions are optional to implement when implementing `ToastDelegate`.

```swift
extension MyViewController: ToastDelegate {

    func willShowToast(_ toast: Toast) {
        print("Toast will be shown after this")
    }

    func didShowToast(_ toast: Toast) {
        print("Toast was shown")
    }

    func willCloseToast(_ toast: Toast) {
        print("Toast will be closed after this")
    }

    func didCloseToast(_ toast: Toast) {
        print("Toast was closed (either automatically, dismissed by user or programmatically)")
    }

}
```

---

Fixes https://github.com/BastiaanJansen/toast-swift/issues/16