### PR TITLE
fix typo: capital letter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ toast.show()
 If you want to add an icon, use the `default` method to construct a toast:
 ```swift
 let toast = Toast.default(
-    image: UIImage(systemname: "airpodspro")!,
+    image: UIImage(systemName: "airpodspro")!,
     title: "Airpods Pro",
     subtitle: "Connected"
 )


### PR DESCRIPTION
Hey, just wanted to make quick pr fixing the typo in code sample: capital letter in the `UIImage(systemName:)` call