### PR TITLE
Add support for attributed strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ let toast = Toast.text("Safari pasted from Notes", subtitle: "A few seconds ago"
 toast.show()
 ```
 
+And if you want to use your own font(NSAttributedString is supported):
+```swift
+let attributes = [
+    NSAttributedStringKey.font: UIFont(name: "HelveticaNeue-Bold", size: 17)!, 
+    NSAttributedStringKey.foregroundColor: UIColor.black
+]
+let attributedString  = NSMutableAttributedString(string: "Safari pasted from Notes" , attributes: attributes)
+let toast = Toast.text(attributedString)
+toast.show()
+```
+
 If you want to add an icon, use the `default` method to construct a toast:
 ```swift
 let toast = Toast.default(

--- a/Sources/Toast/Toast.swift
+++ b/Sources/Toast/Toast.swift
@@ -46,6 +46,21 @@ public class Toast {
     
     /// Creates a new Toast with the default Apple style layout with a title and an optional subtitle.
     /// - Parameters:
+    ///   - title: Attributed title which is displayed in the toast view
+    ///   - subtitle: Optional attributed subtitle which is displayed in the toast view
+    ///   - config: Configuration options
+    /// - Returns: A new Toast view with the configured layout
+    public static func text(
+        _ title: NSAttributedString,
+        subtitle: NSAttributedString? = nil,
+        config: ToastConfiguration = ToastConfiguration()
+    ) -> Toast {
+        let view = AppleToastView(child: TextToastView(title, subtitle: subtitle))
+        return self.init(view: view, config: config)
+    }
+    
+    /// Creates a new Toast with the default Apple style layout with a title and an optional subtitle.
+    /// - Parameters:
     ///   - title: Title which is displayed in the toast view
     ///   - subtitle: Optional subtitle which is displayed in the toast view
     ///   - config: Configuration options
@@ -56,6 +71,27 @@ public class Toast {
         config: ToastConfiguration = ToastConfiguration()
     ) -> Toast {
         let view = AppleToastView(child: TextToastView(title, subtitle: subtitle))
+        return self.init(view: view, config: config)
+    }
+    
+    /// Creates a new Toast with the default Apple style layout with an icon, title and optional subtitle.
+    /// - Parameters:
+    ///   - image: Image which is displayed in the toast view
+    ///   - imageTint: Tint of the image
+    ///   - title: Attributed title which is displayed in the toast view
+    ///   - subtitle: Optional attributed subtitle which is displayed in the toast view
+    ///   - config: Configuration options
+    /// - Returns: A new Toast view with the configured layout
+    public static func `default`(
+        image: UIImage,
+        imageTint: UIColor? = defaultImageTint,
+        title: NSAttributedString,
+        subtitle: NSAttributedString? = nil,
+        config: ToastConfiguration = ToastConfiguration()
+    ) -> Toast {
+        let view = AppleToastView(
+            child: IconAppleToastView(image: image, imageTint: imageTint, title: title, subtitle: subtitle)
+        )
         return self.init(view: view, config: config)
     }
     

--- a/Sources/Toast/ToastViews/AppleToastView/IconAppleToastView.swift
+++ b/Sources/Toast/ToastViews/AppleToastView/IconAppleToastView.swift
@@ -9,6 +9,36 @@ import Foundation
 import UIKit
 
 public class IconAppleToastView : UIStackView {
+    private lazy var vStack: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 2
+        stackView.alignment = .center
+        
+        return stackView
+    }()
+    
+    private lazy var imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        NSLayoutConstraint.activate([
+            imageView.widthAnchor.constraint(equalToConstant: 28),
+            imageView.heightAnchor.constraint(equalToConstant: 28)
+        ])
+        
+        return imageView
+    }()
+    
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        return label
+    }()
+    
+    private lazy var subtitleLabel: UILabel = {
+        UILabel()
+    }()
+    
     public static var defaultImageTint: UIColor {
         if #available(iOS 13.0, *) {
             return .label
@@ -17,47 +47,57 @@ public class IconAppleToastView : UIStackView {
         }
     }
     
-    public init(image: UIImage, imageTint: UIColor? = defaultImageTint, title: String, subtitle: String? = nil) {
+    public init(
+        image: UIImage,
+        imageTint: UIColor? = defaultImageTint,
+        title: NSAttributedString,
+        subtitle: NSAttributedString? = nil
+    ) {
         super.init(frame: CGRect.zero)
-        axis = .horizontal
-        spacing = 15
-        alignment = .center
-        distribution = .fill
+        commonInit()
         
-        let vStack = UIStackView()
-        vStack.axis = .vertical
-        vStack.spacing = 2
-        vStack.alignment = .center
-        
-        let titleLabel = UILabel()
-        titleLabel.text = title
-        titleLabel.font = .systemFont(ofSize: 14, weight: .bold)
-        titleLabel.numberOfLines = 1
-        vStack.addArrangedSubview(titleLabel)
+        self.titleLabel.attributedText = title
+        self.vStack.addArrangedSubview(self.titleLabel)
         
         if let subtitle = subtitle {
-            let subtitleLabel = UILabel()
-            subtitleLabel.textColor = .systemGray
-            subtitleLabel.text = subtitle
-            subtitleLabel.font = .systemFont(ofSize: 12, weight: .bold)
-            vStack.addArrangedSubview(subtitleLabel)
+            self.subtitleLabel.attributedText = subtitle
+            self.vStack.addArrangedSubview(self.subtitleLabel)
         }
         
-        let imageView = UIImageView()
-        imageView.image = image
-        imageView.tintColor = imageTint
-        imageView.contentMode = .scaleAspectFit
+        self.imageView.image = image
+        self.imageView.tintColor = imageTint
         
-        NSLayoutConstraint.activate([
-            imageView.widthAnchor.constraint(equalToConstant: 28),
-            imageView.heightAnchor.constraint(equalToConstant: 28)
-        ])
+        addArrangedSubview(self.imageView)
+        addArrangedSubview(self.vStack)
+    }
+
+    public init(image: UIImage, imageTint: UIColor? = defaultImageTint, title: String, subtitle: String? = nil) {
+        super.init(frame: CGRect.zero)
+        commonInit()
         
-        addArrangedSubview(imageView)
-        addArrangedSubview(vStack)
+        self.titleLabel.text = title
+        self.titleLabel.font = .systemFont(ofSize: 14, weight: .bold)
+        self.vStack.addArrangedSubview(self.titleLabel)
+        
+        if let subtitle = subtitle {
+            self.subtitleLabel.textColor = .systemGray
+            self.subtitleLabel.text = subtitle
+            self.subtitleLabel.font = .systemFont(ofSize: 12, weight: .bold)
+            self.vStack.addArrangedSubview(self.subtitleLabel)
+        }
+        
+        addArrangedSubview(self.imageView)
+        addArrangedSubview(self.vStack)
     }
     
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func commonInit() {
+        axis = .horizontal
+        spacing = 15
+        alignment = .center
+        distribution = .fill
     }
 }

--- a/Sources/Toast/ToastViews/AppleToastView/TextAppleToastView.swift
+++ b/Sources/Toast/ToastViews/AppleToastView/TextAppleToastView.swift
@@ -9,28 +9,52 @@ import Foundation
 import UIKit
 
 public class TextToastView : UIStackView {
-    public init(_ title: String, subtitle: String? = nil) {
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        return label
+    }()
+    
+    private lazy var subtitleLabel: UILabel = {
+        UILabel()
+    }()
+    
+    public init(_ title: NSAttributedString, subtitle: NSAttributedString? = nil) {
         super.init(frame: CGRect.zero)
-        axis = .vertical
-        alignment = .center
-        distribution = .fillEqually
+        commonInit()
         
-        let titleLabel = UILabel()
-        titleLabel.text = title
-        titleLabel.font = .systemFont(ofSize: 14, weight: .bold)
-        titleLabel.numberOfLines = 1
-        addArrangedSubview(titleLabel)
+        self.titleLabel.attributedText = title
+        addArrangedSubview(self.titleLabel)
         
         if let subtitle = subtitle {
-            let subtitleLabel = UILabel()
-            subtitleLabel.textColor = .systemGray
-            subtitleLabel.text = subtitle
-            subtitleLabel.font = .systemFont(ofSize: 12, weight: .bold)
+            self.subtitleLabel.attributedText = subtitle
             addArrangedSubview(subtitleLabel)
+        }
+    }
+    
+    public init(_ title: String, subtitle: String? = nil) {
+        super.init(frame: CGRect.zero)
+        commonInit()
+        
+        self.titleLabel.text = title
+        self.titleLabel.font = .systemFont(ofSize: 14, weight: .bold)
+        addArrangedSubview(self.titleLabel)
+        
+        if let subtitle = subtitle {
+            self.subtitleLabel.textColor = .systemGray
+            self.subtitleLabel.text = subtitle
+            self.subtitleLabel.font = .systemFont(ofSize: 12, weight: .bold)
+            addArrangedSubview(self.subtitleLabel)
         }
     }
     
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func commonInit() {
+        axis = .vertical
+        alignment = .center
+        distribution = .fillEqually
     }
 }


### PR DESCRIPTION
As requested [here](https://github.com/BastiaanJansen/toast-swift/issues/7).
AttributedStrings are now supported for both **icon** and **text** toasts.

Now we can use custom fonts (and everything else NSAttributedString supports)