### PR TITLE
Add ability to choose entering/exiting animations and fix on pan gesture

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The `text`, `default` and `custom` methods support custom configuration options.
 | `enablePanToClose`      | When set to true, the toast will be able to close by swiping up.         | `Bool`         | `true`  |
 | `displayTime`   | The duration the toast will be displayed before it will close when autoHide set to true in seconds. | `TimeInterval` | `4`     |
 | `animationTime` | Duration of the show and close animation in seconds.                                                | `TimeInterval` | `0.2`   |
+| `enteringAnimation` | The type of animation that will be used when toast is showing                                   | `.slide`, `.fade`, `.scaleAndSlide`, `.scale` and `.custom` | `.default`|
+| `exitingAnimation` | The type of animation that will be used when toast is exiting                                    | `.slide`, `.fade`, `.scaleAndSlide`, `.scale` and `.custom` | `.default`|
 | `attachTo`      | The view which the toast view will be attached to.                                                  | `UIView`       | `nil`   |
 
 
@@ -96,6 +98,31 @@ let config = ToastConfiguration(
 
 let toast = toast.text("Safari pasted from Notes", config: config)
 ```
+
+### Custom entering/exiting animations
+```swift
+self.toast = Toast.text(
+            "Safari pasted from Noted",
+            config: .init(
+                direction: .bottom,
+                enteringAnimation: .fade(alphaValue: 0.5),
+                exitingAnimation: .slide(x: 0, y: 100))
+            ).show()
+```
+The above configuration will show a toast that will appear on screen with an animation of fade-in. And then when exiting will go down and disapear.
+
+```swift
+self.toast = Toast.text(
+            "Safari pasted from Noted",
+            config: .init(
+                direction: .bottom,
+                enteringAnimation: .scale(scaleX: 0.6, scaleY: 0.6),
+                exitingAnimation: .default
+            ).show()
+```
+The above configuration will show a toast that will appear on screen with scaling up animation from 0.6 to 1.0. And then when exiting will use our default animation (which is scaleAndSlide)
+
+For more on animation see the `Toast.AnimationType` enum.
 
 ### Custom toast view
 Don't like the default Apple'ish style? No problem, it is also possible to use a custom toast view with the `custom` method. Firstly, create a class that confirms to the `ToastView` protocol:

--- a/Sources/Toast/Toast.swift
+++ b/Sources/Toast/Toast.swift
@@ -13,6 +13,29 @@ public class Toast {
         case top, bottom
     }
     
+    /// Built-in animations for your toast
+    public enum AnimationType {
+        /// Use this type for fading in/out animations.
+        case slide(x: CGFloat, y: CGFloat)
+
+        /// Use this type for fading in/out animations.
+        ///
+        /// alphaValue must be greater or equal to 0 and less or equal to 1.
+        case fade(alphaValue: CGFloat)
+        
+        /// Use this type for scaling and slide in/out animations.
+        case scaleAndSlide(scaleX: CGFloat, scaleY: CGFloat, x: CGFloat, y: CGFloat)
+        
+        /// Use this type for scaling in/out animations.
+        case scale(scaleX: CGFloat, scaleY: CGFloat)
+        
+        /// Use this type for giving your own affine transformation
+        case custom(transformation: CGAffineTransform)
+        
+        /// Currently the default animation if no explicit one specified.
+        case `default`
+    }
+        
     private var closeTimer: Timer?
     
     /// This is for pan gesture to close.

--- a/Sources/Toast/Toast.swift
+++ b/Sources/Toast/Toast.swift
@@ -284,3 +284,42 @@ public extension Toast{
         close()
     }
 }
+
+fileprivate extension Toast.AnimationType {
+    /// Applies the effects to the ToastView.
+    func apply(to view: UIView) {
+        switch self {
+        case .slide(x: let x, y: let y):
+            view.transform = CGAffineTransform(translationX: x, y: y)
+            
+        case .fade(let value):
+            view.alpha = value
+            
+        case .scaleAndSlide(let scaleX, let scaleY, let x, let y):
+            view.transform = CGAffineTransform(scaleX: scaleX, y: scaleY).translatedBy(x: x, y: y)
+            
+        case .scale(let scaleX, let scaleY):
+            view.transform = CGAffineTransform(scaleX: scaleX, y: scaleY)
+            
+        case .custom(let transformation):
+            view.transform = transformation
+            
+        case .`default`:
+            break
+        }
+    }
+    
+    /// Undo the effects from the ToastView so that it never happened.
+    func undo(from view: UIView) {
+        switch self {
+        case .slide, .scaleAndSlide, .scale, .custom:
+            view.transform = .identity
+            
+        case .fade:
+            view.alpha = 1.0
+            
+        case .`default`:
+            break
+        }
+    }
+}

--- a/Sources/Toast/Toast.swift
+++ b/Sources/Toast/Toast.swift
@@ -160,8 +160,7 @@ public class Toast {
         self.config = config
         self.view = view
         self.direction = config.direction
-        
-        view.transform = initialTransform
+                
         if config.enablePanToClose {
             enablePanToClose()
         }
@@ -184,8 +183,9 @@ public class Toast {
         
         delegate?.willShowToast(self)
 
+        config.enteringAnimation.apply(to: self.view)
         UIView.animate(withDuration: config.animationTime, delay: delay, options: [.curveEaseOut, .allowUserInteraction]) {
-            self.view.transform = .identity
+            self.config.enteringAnimation.undo(from: self.view)
         } completion: { [self] _ in
             delegate?.didShowToast(self)
             closeTimer = Timer.scheduledTimer(withTimeInterval: .init(config.displayTime), repeats: false) { [self] _ in
@@ -206,7 +206,7 @@ public class Toast {
                        delay: 0,
                        options: [.curveEaseIn, .allowUserInteraction],
                        animations: {
-            self.view.transform = self.initialTransform
+            self.config.exitingAnimation.apply(to: self.view)
         }, completion: { _ in
             self.view.removeFromSuperview()
             completion?()

--- a/Sources/Toast/ToastConfiguration.swift
+++ b/Sources/Toast/ToastConfiguration.swift
@@ -14,16 +14,20 @@ public struct ToastConfiguration {
     public let enablePanToClose: Bool
     public let displayTime: TimeInterval
     public let animationTime: TimeInterval
+    public let enteringAnimation: Toast.AnimationType
+    public let exitingAnimation: Toast.AnimationType
     
     public let view: UIView?
     
-    
     /// Creates a new Toast configuration object.
     /// - Parameters:
+    ///   - direction: The position the toast will be displayed.
     ///   - autoHide: When set to true, the toast will automatically close itself after display time has elapsed.
     ///   - enablePanToClose: When set to true, the toast will be able to close by swiping up.
     ///   - displayTime: The duration the toast will be displayed before it will close when autoHide set to true.
     ///   - animationTime:Duration of the animation
+    ///   - enteringAnimation: The entering animation of the toast.
+    ///   - exitingAnimation: The exiting animation of the toast.
     ///   - attachTo: The view on which the toast view will be attached.
     public init(
         direction: Toast.Direction = .top,
@@ -31,6 +35,8 @@ public struct ToastConfiguration {
         enablePanToClose: Bool = true,
         displayTime: TimeInterval = 4,
         animationTime: TimeInterval = 0.2,
+        enteringAnimation: Toast.AnimationType = .default,
+        exitingAnimation: Toast.AnimationType = .default,
         attachTo view: UIView? = nil
     ) {
         self.direction = direction
@@ -38,6 +44,37 @@ public struct ToastConfiguration {
         self.enablePanToClose = enablePanToClose
         self.displayTime = displayTime
         self.animationTime = animationTime
+        self.enteringAnimation = enteringAnimation.isDefault ? Self.defaultEnteringAnimation(with: direction) : enteringAnimation
+        self.exitingAnimation = exitingAnimation.isDefault ? Self.defaultExitingAnimation(with: direction) : exitingAnimation
         self.view = view
+    }
+}
+
+// MARK: Default animations
+private extension ToastConfiguration {
+    private static func defaultEnteringAnimation(with direction: Toast.Direction) -> Toast.AnimationType {
+        switch direction {
+        case .top:
+            return .custom(
+                transformation: CGAffineTransform(scaleX: 0.9, y: 0.9).translatedBy(x: 0, y: -100)
+            )
+        case .bottom:
+            return .custom(
+                transformation: CGAffineTransform(scaleX: 0.9, y: 0.9).translatedBy(x: 0, y: 100)
+            )
+        }
+    }
+    
+    private static func defaultExitingAnimation(with direction: Toast.Direction) -> Toast.AnimationType {
+        self.defaultEnteringAnimation(with: direction)
+    }
+}
+
+fileprivate extension Toast.AnimationType {
+    var isDefault: Bool {
+        if case .default = self {
+            return true
+        }
+        return false
     }
 }


### PR DESCRIPTION
Hi there @BastiaanJansen  👋 ,
I found some time and as promised in [#24](https://github.com/BastiaanJansen/toast-swift/issues/24) this PR will give the ability to select your preferred animations. I've added a `.custom` type where user can give his own _AffineAnimation_.
I took it one step further and give the ability to user to select different entering/exiting animations.

Also I fixed an issue I found where panGesture did not work when toast direction is `.bottom`.
Last but not least I changed the pan gesture threshold to `15`.

Have a nice weekend 😄 

