### PR TITLE
Updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The `text`, `default` and `custom` methods support custom configuration options.
 
 ```swift
 let config = ToastConfiguration(
-    direction: .up,
+    direction: .top,
     autoHide: true,
     enablePanToClose: true,
     displayTime: 5,


### PR DESCRIPTION
`ToastConfiguration` API was changed, and in `readme` it was still an old version of API, so changed it and added `.top` instead of `up`