### PR TITLE
Change getting key window code from UIApplication

### DIFF
--- a/Sources/Toast/Toast.swift
+++ b/Sources/Toast/Toast.swift
@@ -206,15 +206,33 @@ public class Toast {
     }
     
     private func topController() -> UIViewController? {
-        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-        
-        if var topController = keyWindow?.rootViewController {
+        if var topController = keyWindow()?.rootViewController {
             while let presentedViewController = topController.presentedViewController {
                 topController = presentedViewController
             }
             return topController
         }
         return nil
+    }
+
+    private func keyWindow() -> UIWindow? {
+        if #available(iOS 13.0, *) {
+            for scene in UIApplication.shared.connectedScenes {
+                guard let windowScene = scene as? UIWindowScene else {
+                    continue
+                }
+                if windowScene.windows.isEmpty {
+                    continue
+                }
+                guard let window = windowScene.windows.first(where: { $0.isKeyWindow }) else {
+                    continue
+                }
+                return window
+            }
+            return nil
+        } else {
+            return UIApplication.shared.windows.first(where: { $0.isKeyWindow })
+        }
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
![스크린샷 2023-02-03 오후 4 21 22](https://user-images.githubusercontent.com/24635384/216538796-5fc7b9f5-4dd7-4fc3-917e-bb7b91c2c43c.png)

as you know, `UIApplication.shared.windows` was deprecated in iOS 15.0  
so we have to using`UIApplication.shared.connectedScenes` instead of `windows`  

this PR make removing `UIApplication.shared.windows` deprecated warning