### PR TITLE
Support UILabel.numberOfLines

### DIFF
--- a/Sources/Toast/Toast.swift
+++ b/Sources/Toast/Toast.swift
@@ -41,7 +41,7 @@ public class Toast {
         viewConfig: ToastViewConfiguration = ToastViewConfiguration(),
         config: ToastConfiguration = ToastConfiguration()
     ) -> Toast {
-        let view = AppleToastView(child: TextToastView(title, subtitle: subtitle), config: viewConfig)
+        let view = AppleToastView(child: TextToastView(title, subtitle: subtitle, viewConfig: viewConfig), config: viewConfig)
         return self.init(view: view, config: config)
     }
     
@@ -57,7 +57,7 @@ public class Toast {
         viewConfig: ToastViewConfiguration = ToastViewConfiguration(),
         config: ToastConfiguration = ToastConfiguration()
     ) -> Toast {
-        let view = AppleToastView(child: TextToastView(title, subtitle: subtitle), config: viewConfig)
+        let view = AppleToastView(child: TextToastView(title, subtitle: subtitle, viewConfig: viewConfig), config: viewConfig)
         return self.init(view: view, config: config)
     }
     

--- a/Sources/Toast/Toast.swift
+++ b/Sources/Toast/Toast.swift
@@ -78,7 +78,7 @@ public class Toast {
         config: ToastConfiguration = ToastConfiguration()
     ) -> Toast {
         let view = AppleToastView(
-            child: IconAppleToastView(image: image, imageTint: imageTint, title: title, subtitle: subtitle),
+            child: IconAppleToastView(image: image, imageTint: imageTint, title: title, subtitle: subtitle, viewConfig: viewConfig),
             config: viewConfig
         )
         return self.init(view: view, config: config)
@@ -101,7 +101,7 @@ public class Toast {
         config: ToastConfiguration = ToastConfiguration()
     ) -> Toast {
         let view = AppleToastView(
-            child: IconAppleToastView(image: image, imageTint: imageTint, title: title, subtitle: subtitle),
+            child: IconAppleToastView(image: image, imageTint: imageTint, title: title, subtitle: subtitle, viewConfig: viewConfig),
             config: viewConfig
         )
         return self.init(view: view, config: config)

--- a/Sources/Toast/ToastConfiguration.swift
+++ b/Sources/Toast/ToastConfiguration.swift
@@ -14,9 +14,11 @@ public struct ToastConfiguration {
     public let animationTime: TimeInterval
     public let enteringAnimation: Toast.AnimationType
     public let exitingAnimation: Toast.AnimationType
-    
+    public let titleNumberOfLines: Int
+    public let subTitleNumberOfLines: Int
+
     public let view: UIView?
-    
+
     /// Creates a new Toast configuration object.
     /// - Parameters:
     ///   - direction: The position the toast will be displayed.
@@ -31,6 +33,8 @@ public struct ToastConfiguration {
         animationTime: TimeInterval = 0.2,
         enteringAnimation: Toast.AnimationType = .default,
         exitingAnimation: Toast.AnimationType = .default,
+        titleNumberOfLines: Int = 1,
+        subTitleNumberOfLines: Int = 1,
         attachTo view: UIView? = nil
     ) {
         self.direction = direction
@@ -38,6 +42,8 @@ public struct ToastConfiguration {
         self.animationTime = animationTime
         self.enteringAnimation = enteringAnimation.isDefault ? Self.defaultEnteringAnimation(with: direction) : enteringAnimation
         self.exitingAnimation = exitingAnimation.isDefault ? Self.defaultExitingAnimation(with: direction) : exitingAnimation
+        self.titleNumberOfLines = titleNumberOfLines
+        self.subTitleNumberOfLines = subTitleNumberOfLines
         self.view = view
     }
 }

--- a/Sources/Toast/ToastConfiguration.swift
+++ b/Sources/Toast/ToastConfiguration.swift
@@ -14,8 +14,6 @@ public struct ToastConfiguration {
     public let animationTime: TimeInterval
     public let enteringAnimation: Toast.AnimationType
     public let exitingAnimation: Toast.AnimationType
-    public let titleNumberOfLines: Int
-    public let subTitleNumberOfLines: Int
 
     public let view: UIView?
 
@@ -33,8 +31,6 @@ public struct ToastConfiguration {
         animationTime: TimeInterval = 0.2,
         enteringAnimation: Toast.AnimationType = .default,
         exitingAnimation: Toast.AnimationType = .default,
-        titleNumberOfLines: Int = 1,
-        subTitleNumberOfLines: Int = 1,
         attachTo view: UIView? = nil
     ) {
         self.direction = direction
@@ -42,8 +38,6 @@ public struct ToastConfiguration {
         self.animationTime = animationTime
         self.enteringAnimation = enteringAnimation.isDefault ? Self.defaultEnteringAnimation(with: direction) : enteringAnimation
         self.exitingAnimation = exitingAnimation.isDefault ? Self.defaultExitingAnimation(with: direction) : exitingAnimation
-        self.titleNumberOfLines = titleNumberOfLines
-        self.subTitleNumberOfLines = subTitleNumberOfLines
         self.view = view
     }
 }

--- a/Sources/Toast/ToastViews/AppleToastView/IconAppleToastView.swift
+++ b/Sources/Toast/ToastViews/AppleToastView/IconAppleToastView.swift
@@ -31,7 +31,6 @@ public class IconAppleToastView : UIStackView {
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.numberOfLines = 1
         return label
     }()
     
@@ -51,16 +50,19 @@ public class IconAppleToastView : UIStackView {
         image: UIImage,
         imageTint: UIColor? = defaultImageTint,
         title: NSAttributedString,
-        subtitle: NSAttributedString? = nil
+        subtitle: NSAttributedString? = nil,
+        viewConfig: ToastViewConfiguration
     ) {
         super.init(frame: CGRect.zero)
         commonInit()
         
         self.titleLabel.attributedText = title
+        self.titleLabel.numberOfLines = viewConfig.titleNumberOfLines
         self.vStack.addArrangedSubview(self.titleLabel)
         
         if let subtitle = subtitle {
             self.subtitleLabel.attributedText = subtitle
+            self.subtitleLabel.numberOfLines = viewConfig.subtitleNumberOfLines
             self.vStack.addArrangedSubview(self.subtitleLabel)
         }
         
@@ -71,17 +73,19 @@ public class IconAppleToastView : UIStackView {
         addArrangedSubview(self.vStack)
     }
 
-    public init(image: UIImage, imageTint: UIColor? = defaultImageTint, title: String, subtitle: String? = nil) {
+    public init(image: UIImage, imageTint: UIColor? = defaultImageTint, title: String, subtitle: String? = nil, viewConfig: ToastViewConfiguration) {
         super.init(frame: CGRect.zero)
         commonInit()
         
         self.titleLabel.text = title
+        self.titleLabel.numberOfLines = viewConfig.titleNumberOfLines
         self.titleLabel.font = .systemFont(ofSize: 14, weight: .bold)
         self.vStack.addArrangedSubview(self.titleLabel)
         
         if let subtitle = subtitle {
             self.subtitleLabel.textColor = .systemGray
             self.subtitleLabel.text = subtitle
+            self.subtitleLabel.numberOfLines = viewConfig.subtitleNumberOfLines
             self.subtitleLabel.font = .systemFont(ofSize: 12, weight: .bold)
             self.vStack.addArrangedSubview(self.subtitleLabel)
         }

--- a/Sources/Toast/ToastViews/AppleToastView/IconAppleToastView.swift
+++ b/Sources/Toast/ToastViews/AppleToastView/IconAppleToastView.swift
@@ -30,8 +30,7 @@ public class IconAppleToastView : UIStackView {
     }()
     
     private lazy var titleLabel: UILabel = {
-        let label = UILabel()
-        return label
+        UILabel()
     }()
     
     private lazy var subtitleLabel: UILabel = {

--- a/Sources/Toast/ToastViews/AppleToastView/TextAppleToastView.swift
+++ b/Sources/Toast/ToastViews/AppleToastView/TextAppleToastView.swift
@@ -10,8 +10,7 @@ import UIKit
 
 public class TextToastView : UIStackView {
     private lazy var titleLabel: UILabel = {
-        let label = UILabel()
-        return label
+        UILabel()
     }()
     
     private lazy var subtitleLabel: UILabel = {

--- a/Sources/Toast/ToastViews/AppleToastView/TextAppleToastView.swift
+++ b/Sources/Toast/ToastViews/AppleToastView/TextAppleToastView.swift
@@ -11,7 +11,6 @@ import UIKit
 public class TextToastView : UIStackView {
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.numberOfLines = 1
         return label
     }()
     
@@ -19,30 +18,34 @@ public class TextToastView : UIStackView {
         UILabel()
     }()
     
-    public init(_ title: NSAttributedString, subtitle: NSAttributedString? = nil) {
+    public init(_ title: NSAttributedString, subtitle: NSAttributedString? = nil, viewConfig: ToastViewConfiguration) {
         super.init(frame: CGRect.zero)
         commonInit()
         
         self.titleLabel.attributedText = title
+        self.titleLabel.numberOfLines = viewConfig.titleNumberOfLines
         addArrangedSubview(self.titleLabel)
         
         if let subtitle = subtitle {
             self.subtitleLabel.attributedText = subtitle
+            self.subtitleLabel.numberOfLines = viewConfig.subtitleNumberOfLines
             addArrangedSubview(subtitleLabel)
         }
     }
     
-    public init(_ title: String, subtitle: String? = nil) {
+    public init(_ title: String, subtitle: String? = nil, viewConfig: ToastViewConfiguration) {
         super.init(frame: CGRect.zero)
         commonInit()
         
         self.titleLabel.text = title
+        self.titleLabel.numberOfLines = viewConfig.titleNumberOfLines
         self.titleLabel.font = .systemFont(ofSize: 14, weight: .bold)
         addArrangedSubview(self.titleLabel)
         
         if let subtitle = subtitle {
             self.subtitleLabel.textColor = .systemGray
             self.subtitleLabel.text = subtitle
+            self.subtitleLabel.numberOfLines = viewConfig.subtitleNumberOfLines
             self.subtitleLabel.font = .systemFont(ofSize: 12, weight: .bold)
             addArrangedSubview(self.subtitleLabel)
         }


### PR DESCRIPTION
This is a P-R to resolve Issue #36.

This P-R is based on https://github.com/BastiaanJansen/toast-swift/pull/37 and the comment https://github.com/BastiaanJansen/toast-swift/pull/37#issuecomment-1717836140 .

There was already a `NumberOfLines` parameter in the `ToastViewConfiguration` but it was not used. So I changed the implementation to use the value in `IconAppleToastView` and `TextAppleToastView`.