### PR TITLE
feat: add option to close overlapped toasts

### DIFF
--- a/Sources/Toast/Toast.swift
+++ b/Sources/Toast/Toast.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 public class Toast {
-    private static var queue = [Toast]()
+    private static var activeToasts = [Toast]()
     
     public let view: ToastView
     private var backgroundView: UIView?
@@ -181,12 +181,12 @@ public class Toast {
             if !config.allowToastOverlap {
                 closeOverlappedToasts()
             }
-            Toast.queue.append(self)
+            Toast.activeToasts.append(self)
         }
     }
     
     private func closeOverlappedToasts() {
-        Toast.queue.forEach {
+        Toast.activeToasts.forEach {
             $0.closeTimer?.invalidate()
             $0.close(animated: false)
         }
@@ -210,8 +210,8 @@ public class Toast {
         }, completion: { _ in
             self.backgroundView?.removeFromSuperview()
             self.view.removeFromSuperview()
-            if let index = Toast.queue.firstIndex(where: { $0 == self }) {
-                Toast.queue.remove(at: index)
+            if let index = Toast.activeToasts.firstIndex(where: { $0 == self }) {
+                Toast.activeToasts.remove(at: index)
             }
             completion?()
             self.multicast.invoke { $0.didCloseToast(self) }

--- a/Sources/Toast/Toast.swift
+++ b/Sources/Toast/Toast.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 public class Toast {
+    private static var queue = [Toast]()
     
     public let view: ToastView
     private var backgroundView: UIView?
@@ -177,24 +178,41 @@ public class Toast {
             multicast.invoke { $0.didShowToast(self) }
             
             configureCloseTimer()
+            if !config.allowToastOverlap {
+                closeOverlappedToasts()
+            }
+            Toast.queue.append(self)
+        }
+    }
+    
+    private func closeOverlappedToasts() {
+        Toast.queue.forEach {
+            $0.closeTimer?.invalidate()
+            $0.close(animated: false)
         }
     }
     
     /// Close the toast
     /// - Parameters:
     ///   - completion: A completion handler which is invoked after the toast is hidden
-    public func close(completion: (() -> Void)? = nil) {
+    ///   - animated: A Boolean value that determines whether to apply animation.
+    public func close(animated: Bool = true, completion: (() -> Void)? = nil) {
         multicast.invoke { $0.willCloseToast(self) }
 
         UIView.animate(withDuration: config.animationTime,
                        delay: 0,
                        options: [.curveEaseIn, .allowUserInteraction],
                        animations: {
-            self.config.exitingAnimation.apply(to: self.view)
+            if animated {
+                self.config.exitingAnimation.apply(to: self.view)
+            }
             self.backgroundView?.backgroundColor = .clear
         }, completion: { _ in
             self.backgroundView?.removeFromSuperview()
             self.view.removeFromSuperview()
+            if let index = Toast.queue.firstIndex(where: { $0 == self }) {
+                Toast.queue.remove(at: index)
+            }
             completion?()
             self.multicast.invoke { $0.didCloseToast(self) }
         })
@@ -309,5 +327,11 @@ extension Toast {
     public enum Background: Equatable {
         case none,
              color(color: UIColor = defaultImageTint.withAlphaComponent(0.25))
+    }
+}
+
+extension Toast: Equatable {
+    public static func == (lhs: Toast, rhs: Toast) -> Bool {
+        return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
 }

--- a/Sources/Toast/ToastConfiguration.swift
+++ b/Sources/Toast/ToastConfiguration.swift
@@ -15,6 +15,7 @@ public struct ToastConfiguration {
     public let enteringAnimation: Toast.AnimationType
     public let exitingAnimation: Toast.AnimationType
     public let background: Toast.Background
+    public let allowToastOverlap: Bool
 
     public let view: UIView?
 
@@ -26,6 +27,7 @@ public struct ToastConfiguration {
     ///   - enteringAnimation: The entering animation of the toast.
     ///   - exitingAnimation: The exiting animation of the toast.
     ///   - attachTo: The view on which the toast view will be attached.
+    ///   - allowToastOverlap: Allows new toasts to appear over existing ones.
     public init(
         direction: Toast.Direction = .top,
         dismissBy: [Toast.Dismissable] = [.time(time: 4.0), .swipe(direction: .natural)],
@@ -33,7 +35,8 @@ public struct ToastConfiguration {
         enteringAnimation: Toast.AnimationType = .default,
         exitingAnimation: Toast.AnimationType = .default,
         attachTo view: UIView? = nil,
-        background: Toast.Background = .none
+        background: Toast.Background = .none,
+        allowToastOverlap: Bool = true
     ) {
         self.direction = direction
         self.dismissables = dismissBy
@@ -42,6 +45,7 @@ public struct ToastConfiguration {
         self.exitingAnimation = exitingAnimation.isDefault ? Self.defaultExitingAnimation(with: direction) : exitingAnimation
         self.view = view
         self.background = background
+        self.allowToastOverlap = allowToastOverlap
     }
 }
 


### PR DESCRIPTION
Hello ! @BastiaanJansen 
When multiple toast messages appear, the existing messages remain visible. 
I suggest an option that naturally dismisses the existing messages when new toast messages overlap.

here is an example

```
let config = ToastConfiguration(allowToastOverlap: false)
let toast = Toast.default(
       image: UIImage(systemName: "airpodspro")!,
       title: "Airpods Pro",
       subtitle: "Connected",
       config: config
)
toast.show()
```