### PR TITLE
Update podspec platform support to match SwiftPM.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "Toast",
     platforms: [
-        .iOS(.v11), .tvOS(.v13)
+        .iOS(.v11),
+        .tvOS(.v13)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,7 +7,8 @@ let package = Package(
     name: "Toast",
     platforms: [
         .iOS(.v11),
-        .tvOS(.v13)
+        .tvOS(.v13),
+        .visionOS(.v1)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Toast",
     platforms: [
-        .iOS(.v11),
+        .iOS(.v12),
         .tvOS(.v13),
         .visionOS(.v1)
     ],

--- a/ToastViewSwift.podspec
+++ b/ToastViewSwift.podspec
@@ -65,7 +65,8 @@ Pod::Spec.new do |spec|
   #
 
   spec.ios.deployment_target      = "11.0"
-  spec.tvos.deployment_target      = "13.0"
+  spec.tvos.deployment_target     = "13.0"
+  spec.visionos.deployment_target = "1.0"
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #

--- a/ToastViewSwift.podspec
+++ b/ToastViewSwift.podspec
@@ -64,7 +64,7 @@ Pod::Spec.new do |spec|
   #  the deployment target. You can optionally include the target after the platform.
   #
 
-  spec.ios.deployment_target      = "11.0"
+  spec.ios.deployment_target      = "12.0"
   spec.tvos.deployment_target     = "13.0"
   spec.visionos.deployment_target = "1.0"
 

--- a/ToastViewSwift.podspec
+++ b/ToastViewSwift.podspec
@@ -64,15 +64,8 @@ Pod::Spec.new do |spec|
   #  the deployment target. You can optionally include the target after the platform.
   #
 
-  # spec.platform     = :ios
-  spec.platform     = :ios, "11.0"
-
-  #  When using multiple platforms
-  # spec.ios.deployment_target = "5.0"
-  # spec.osx.deployment_target = "10.7"
-  # spec.watchos.deployment_target = "2.0"
-  # spec.tvos.deployment_target = "9.0"
-
+  spec.ios.deployment_target      = "11.0"
+  spec.tvos.deployment_target      = "13.0"
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #


### PR DESCRIPTION
The SwiftPM `Package.swift` has specified tvOS support but this isn't also specified for Cocoapods. This PR will match up the 2 so both specify tvOS support.

@BastiaanJansen Could you take a look?

## Discussion

_~~What about visionOS support? Haven't tested using this library on visionOS yet (would like to) but maybe we could add visionOS as a supported platform to both SwiftPM and Cocoapods if it works out of the box?~~_

_~~Or maybe that should be out of scope for this PR and should be handled in a new PR, but wanted to open the discussion.~~_

Edit: visionOS support was added, but support for iOS 11 was dropped in this PR.