### PR TITLE
Bigger font size for tvOS

### DIFF
--- a/Sources/Toast/ToastViews/AppleToastView/IconAppleToastView.swift
+++ b/Sources/Toast/ToastViews/AppleToastView/IconAppleToastView.swift
@@ -78,14 +78,14 @@ public class IconAppleToastView : UIStackView {
         
         self.titleLabel.text = title
         self.titleLabel.numberOfLines = viewConfig.titleNumberOfLines
-        self.titleLabel.font = .systemFont(ofSize: 14, weight: .bold)
+        self.titleLabel.font = .systemFont(ofSize: titleTextSize, weight: .bold)
         self.vStack.addArrangedSubview(self.titleLabel)
         
         if let subtitle = subtitle {
             self.subtitleLabel.textColor = .systemGray
             self.subtitleLabel.text = subtitle
             self.subtitleLabel.numberOfLines = viewConfig.subtitleNumberOfLines
-            self.subtitleLabel.font = .systemFont(ofSize: 12, weight: .bold)
+            self.subtitleLabel.font = .systemFont(ofSize: subtitleTextSize, weight: .bold)
             self.vStack.addArrangedSubview(self.subtitleLabel)
         }
         

--- a/Sources/Toast/ToastViews/AppleToastView/TextAppleToastView.swift
+++ b/Sources/Toast/ToastViews/AppleToastView/TextAppleToastView.swift
@@ -38,14 +38,14 @@ public class TextToastView : UIStackView {
         
         self.titleLabel.text = title
         self.titleLabel.numberOfLines = viewConfig.titleNumberOfLines
-        self.titleLabel.font = .systemFont(ofSize: 14, weight: .bold)
+        self.titleLabel.font = .systemFont(ofSize: titleTextSize, weight: .bold)
         addArrangedSubview(self.titleLabel)
         
         if let subtitle = subtitle {
             self.subtitleLabel.textColor = .systemGray
             self.subtitleLabel.text = subtitle
             self.subtitleLabel.numberOfLines = viewConfig.subtitleNumberOfLines
-            self.subtitleLabel.font = .systemFont(ofSize: 12, weight: .bold)
+            self.subtitleLabel.font = .systemFont(ofSize: subtitleTextSize, weight: .bold)
             addArrangedSubview(self.subtitleLabel)
         }
     }

--- a/Sources/Toast/ToastViews/ViewValues.swift
+++ b/Sources/Toast/ToastViews/ViewValues.swift
@@ -1,0 +1,16 @@
+//
+//  ViewValues.swift
+//
+//
+//  Created by romain.gyh on 08/02/2024.
+//
+
+import Foundation
+
+#if os(iOS) || os(watchOS)
+let titleTextSize = 14.0
+let subtitleTextSize = 12.0
+#else
+let titleTextSize = 28.0
+let subtitleTextSize = 24.0
+#endif


### PR DESCRIPTION
Hello !

Just a small PR to increase the font size on large screens (tvOS and visionOS).
I've put font sizes as constants depenging on os in `ViewValues.swift`, I don't know if it's a common practice I'm pretty new in SwiftUI.

### iOS font sizez
Same as before
- Title : 14
- Subtitle 12

### tvOS and visionOS font sizez
Twice bigger
- Title : 28
- Subtitle 24

