### PR TITLE
feat: support fixedSize

### DIFF
--- a/Sources/Toast/Toast.swift
+++ b/Sources/Toast/Toast.swift
@@ -43,7 +43,7 @@ public class Toast {
         viewConfig: ToastViewConfiguration = ToastViewConfiguration(),
         config: ToastConfiguration = ToastConfiguration()
     ) -> Toast {
-        let view = AppleToastView(child: TextToastView(title, subtitle: subtitle, viewConfig: viewConfig), config: viewConfig)
+        let view = AppleToastView(child: TextToastView(title, subtitle: subtitle, viewConfig: viewConfig), config: viewConfig, fixedHeight: config.fixedSize?.height, fixedWidth: config.fixedSize?.width)
         return self.init(view: view, config: config)
     }
     
@@ -59,7 +59,7 @@ public class Toast {
         viewConfig: ToastViewConfiguration = ToastViewConfiguration(),
         config: ToastConfiguration = ToastConfiguration()
     ) -> Toast {
-        let view = AppleToastView(child: TextToastView(title, subtitle: subtitle, viewConfig: viewConfig), config: viewConfig)
+        let view = AppleToastView(child: TextToastView(title, subtitle: subtitle, viewConfig: viewConfig), config: viewConfig, fixedHeight: config.fixedSize?.height, fixedWidth: config.fixedSize?.width)
         return self.init(view: view, config: config)
     }
     
@@ -81,7 +81,7 @@ public class Toast {
     ) -> Toast {
         let view = AppleToastView(
             child: IconAppleToastView(image: image, imageTint: imageTint, title: title, subtitle: subtitle, viewConfig: viewConfig),
-            config: viewConfig
+            config: viewConfig, fixedHeight: config.fixedSize?.height, fixedWidth: config.fixedSize?.width
         )
         return self.init(view: view, config: config)
     }
@@ -104,7 +104,7 @@ public class Toast {
     ) -> Toast {
         let view = AppleToastView(
             child: IconAppleToastView(image: image, imageTint: imageTint, title: title, subtitle: subtitle, viewConfig: viewConfig),
-            config: viewConfig
+            config: viewConfig, fixedHeight: config.fixedSize?.height, fixedWidth: config.fixedSize?.width
         )
         return self.init(view: view, config: config)
     }

--- a/Sources/Toast/ToastConfiguration.swift
+++ b/Sources/Toast/ToastConfiguration.swift
@@ -16,6 +16,7 @@ public struct ToastConfiguration {
     public let exitingAnimation: Toast.AnimationType
     public let background: Toast.Background
     public let allowToastOverlap: Bool
+    public let fixedSize: CGSize?
 
     public let view: UIView?
 
@@ -23,11 +24,12 @@ public struct ToastConfiguration {
     /// - Parameters:
     ///   - direction: The position the toast will be displayed.
     ///   - dismissBy: Choose when the toast dismisses.
-    ///   - animationTime:Duration of the animation
+    ///   - animationTime: Duration of the animation
     ///   - enteringAnimation: The entering animation of the toast.
     ///   - exitingAnimation: The exiting animation of the toast.
     ///   - attachTo: The view on which the toast view will be attached.
     ///   - allowToastOverlap: Allows new toasts to appear over existing ones.
+    ///   - fixedSize: Exact toast size in points
     public init(
         direction: Toast.Direction = .top,
         dismissBy: [Toast.Dismissable] = [.time(time: 4.0), .swipe(direction: .natural)],
@@ -36,7 +38,8 @@ public struct ToastConfiguration {
         exitingAnimation: Toast.AnimationType = .default,
         attachTo view: UIView? = nil,
         background: Toast.Background = .none,
-        allowToastOverlap: Bool = true
+        allowToastOverlap: Bool = true,
+        fixedSize: CGSize? = nil
     ) {
         self.direction = direction
         self.dismissables = dismissBy
@@ -46,6 +49,7 @@ public struct ToastConfiguration {
         self.view = view
         self.background = background
         self.allowToastOverlap = allowToastOverlap
+        self.fixedSize = fixedSize
     }
 }
 

--- a/Sources/Toast/ToastViews/AppleToastView/AppleToastView.swift
+++ b/Sources/Toast/ToastViews/AppleToastView/AppleToastView.swift
@@ -15,12 +15,19 @@ public class AppleToastView : UIView, ToastView {
     
     private var toast: Toast?
     
+    private let fixedHeight: CGFloat?
+    private let fixedWidth: CGFloat?
+    
     public init(
         child: UIView,
-        config: ToastViewConfiguration = ToastViewConfiguration()
+        config: ToastViewConfiguration = ToastViewConfiguration(),
+        fixedHeight: CGFloat? = nil,
+        fixedWidth: CGFloat? = nil
     ) {
         self.config = config
         self.child = child
+        self.fixedHeight = fixedHeight
+        self.fixedWidth = fixedWidth
         super.init(frame: .zero)
         
         addSubview(child)
@@ -36,13 +43,30 @@ public class AppleToastView : UIView, ToastView {
         guard let superview = superview else { return }
         translatesAutoresizingMaskIntoConstraints = false
         
-        NSLayoutConstraint.activate([
-            heightAnchor.constraint(greaterThanOrEqualToConstant: config.minHeight),
-            widthAnchor.constraint(greaterThanOrEqualToConstant: config.minWidth),
+        var constraints: [NSLayoutConstraint] = [
             leadingAnchor.constraint(greaterThanOrEqualTo: superview.leadingAnchor, constant: 10),
             trailingAnchor.constraint(lessThanOrEqualTo: superview.trailingAnchor, constant: -10),
             centerXAnchor.constraint(equalTo: superview.centerXAnchor)
-        ])
+        ]
+        
+        /// Height:
+        /// - If a fixed height is provided, enforce an exact height (==).
+        /// - Otherwise, only enforce a minimum (≥) so the view can expand with content.
+        if let fixedHeight = fixedHeight {
+            constraints.append(heightAnchor.constraint(equalToConstant: fixedHeight))
+        } else {
+            constraints.append(heightAnchor.constraint(greaterThanOrEqualToConstant: config.minHeight))
+        }
+
+        /// Width:
+        /// - If a fixed width is provided, enforce an exact width (==).
+        /// - Otherwise, only enforce a minimum (≥); actual width will be determined
+        ///   by content size up to the available space (bounded by leading/trailing).
+        if let fixedWidth = fixedWidth {
+            constraints.append(widthAnchor.constraint(equalToConstant: fixedWidth))
+        } else {
+            constraints.append(widthAnchor.constraint(greaterThanOrEqualToConstant: config.minWidth))
+        }
         
         switch toast.config.direction {
         case .bottom:
@@ -53,6 +77,7 @@ public class AppleToastView : UIView, ToastView {
             centerYAnchor.constraint(equalTo: superview.layoutMarginsGuide.centerYAnchor, constant: 0).isActive = true
         }
         
+        NSLayoutConstraint.activate(constraints)
         addSubviewConstraints()
         DispatchQueue.main.async {
             self.style()


### PR DESCRIPTION
Hello! @BastiaanJansen
Some apps need pixel-perfect toast dimensions.
The current behavior is content-adaptive with minimums, so width/height vary with text length.
And size could be configured through a custom toast view.
This PR can set a fixedSize parameter in ToastConfiguration, enabling easier, declarative sizing without implementing a custom view.
<br>

#### How Develop
• Added fixedSize: CGSize? to ToastConfiguration.
• Threaded fixedSize through the Toast factories to AppleToastView.
• When set, AppleToastView applies equalToConstant for width/height (exact size). When nil, the existing adaptive sizing is unchanged (backward-compatible).
<br>

Here is an example
```
// Exact 280×58 toast
let toast = Toast.text(
    "Saved!",
    config: ToastConfiguration(fixedSize: CGSize(width: 280, height: 58))
)
toast.show()

// Icon variant
let toast2 = Toast.default(
    image: UIImage(systemName: "checkmark.circle.fill")!,
    title: "Completed",
    config: ToastConfiguration(fixedSize: CGSize(width: 260, height: 58))
)
toast2.show()
```